### PR TITLE
Multiclass relative fix, Fuel decimal configuration, Fuel reserve configuration

### DIFF
--- a/OverlayDDU.h
+++ b/OverlayDDU.h
@@ -445,13 +445,14 @@ class OverlayDDU : public Overlay
                 }
                 
                 m_brush->SetColor( textCol );
-                m_text.render( m_renderTarget.Get(), L"Laps", m_textFormat.Get(),      m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*2.8f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
-                m_text.render( m_renderTarget.Get(), L"Rem", m_textFormatSmall.Get(), m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*5.1f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
-                m_text.render( m_renderTarget.Get(), L"Per", m_textFormatSmall.Get(), m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*6.9f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
-                m_text.render( m_renderTarget.Get(), L"Fin+", m_textFormatSmall.Get(), m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*8.7f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
-                m_text.render( m_renderTarget.Get(), L"Add", m_textFormatSmall.Get(), m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*10.5f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
+                m_text.render( m_renderTarget.Get(), L"Laps", m_textFormat.Get(),      m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*2.3f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
+                m_text.render( m_renderTarget.Get(), L"Rem", m_textFormatSmall.Get(), m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*4.6f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
+                m_text.render( m_renderTarget.Get(), L"Per", m_textFormatSmall.Get(), m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*6.4f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
+                m_text.render( m_renderTarget.Get(), L"Fin+", m_textFormatSmall.Get(), m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*8.2f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
+                m_text.render( m_renderTarget.Get(), L"Add", m_textFormatSmall.Get(), m_boxFuel.x0+xoff, m_boxFuel.x1, m_boxFuel.y0+m_boxFuel.h*10.0f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_LEADING );
 
                 const float estimateFactor = g_cfg.getFloat( m_name, "fuel_estimate_factor", 1.1f );
+                const float fuelReserveMargin = g_cfg.getFloat(m_name, "fuel_reserve_margin", 0.25f);
                 const float remainingFuel  = ir_FuelLevel.getFloat();
 
                 // Update average fuel consumption tracking. Ignore laps that weren't entirely under green or where we pitted.
@@ -488,9 +489,9 @@ class OverlayDDU : public Overlay
                 const float perLapConsEst = avgPerLap * estimateFactor;  // conservative estimate of per-lap use for further calculations
                 if( perLapConsEst > 0 )
                 {
-                    const float estLaps = remainingFuel / perLapConsEst;
-                    swprintf( s, _countof(s), L"%.*f", estLaps<10?1:0, estLaps );
-                    m_text.render( m_renderTarget.Get(), s, m_textFormatBold.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*2.8f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
+                    const float estLaps = (remainingFuel-fuelReserveMargin) / perLapConsEst;
+                    swprintf( s, _countof(s), L"%.1f", estLaps );
+                    m_text.render( m_renderTarget.Get(), s, m_textFormatBold.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*3.0f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
                 }
 
                 // Remaining
@@ -499,8 +500,8 @@ class OverlayDDU : public Overlay
                     float val = remainingFuel;
                     if( imperial )
                         val *= 0.264172f;
-                    swprintf( s, _countof(s), imperial ? L"%.1f gl" : L"%.1f lt", val );
-                    m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*5.1f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
+                    swprintf( s, _countof(s), imperial ? L"%.2f gl" : L"%.2f lt", val );
+                    m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*5.3f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
                 }
 
                 // Per Lap
@@ -509,8 +510,8 @@ class OverlayDDU : public Overlay
                     float val = avgPerLap;
                     if( imperial )
                         val *= 0.264172f;
-                    swprintf( s, _countof(s), imperial ? L"%.1f gl" : L"%.2f lt", val );
-                    m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*6.9f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
+                    swprintf( s, _countof(s), imperial ? L"%.2f gl" : L"%.2f lt", val );
+                    m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*7.1f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
                 }
 
                 // To Finish
@@ -525,8 +526,8 @@ class OverlayDDU : public Overlay
 
                     if( imperial )
                         toFinish *= 0.264172f;
-                    swprintf( s, _countof(s), imperial ? L"%3.1f gl" : L"%3.1f lt", toFinish );
-                    m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*8.7f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
+                    swprintf( s, _countof(s), imperial ? L"%3.2f gl" : L"%3.2f lt", toFinish );
+                    m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*8.9f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
                     m_brush->SetColor( textCol );
                 }
 
@@ -539,8 +540,8 @@ class OverlayDDU : public Overlay
 
                     if( imperial )
                         add *= 0.264172f;
-                    swprintf( s, _countof(s), imperial ? L"%3.1f gl" : L"%3.1f lt", add );
-                    m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*10.5f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
+                    swprintf( s, _countof(s), imperial ? L"%3.2f gl" : L"%3.2f lt", add );
+                    m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*10.7f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
                     m_brush->SetColor( textCol );
                 }
             }

--- a/OverlayDDU.h
+++ b/OverlayDDU.h
@@ -490,7 +490,7 @@ class OverlayDDU : public Overlay
                 if( perLapConsEst > 0 )
                 {
                     const float estLaps = (remainingFuel-fuelReserveMargin) / perLapConsEst;
-                    swprintf( s, _countof(s), L"%.1f", estLaps );
+                    swprintf( s, _countof(s), L"%.*f", g_cfg.getInt( m_name, "fuel_decimal_places", 2), estLaps);
                     m_text.render( m_renderTarget.Get(), s, m_textFormatBold.Get(), m_boxFuel.x0, m_boxFuel.x1-xoff, m_boxFuel.y0+m_boxFuel.h*3.0f/12.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_TRAILING );
                 }
 

--- a/OverlayRelative.h
+++ b/OverlayRelative.h
@@ -100,6 +100,7 @@ class OverlayRelative : public Overlay
             };
             std::vector<CarInfo> relatives;
             relatives.reserve( IR_MAX_CARS );
+            const float ownClassEstLaptime = ir_session.cars[ir_session.driverCarIdx].carClassEstLapTime;
 
             // Populate cars with the ones for which a relative/delta comparison is valid
             for( int i=0; i<IR_MAX_CARS; ++i )
@@ -121,7 +122,8 @@ class OverlayRelative : public Overlay
                     int   lapDelta = lapcountC - lapcountS;
 
                     const float L = ir_estimateLaptime();
-                    const float C = ir_CarIdxEstTime.getFloat(i);
+                    const float LClassRatio = car.carClassEstLapTime / ownClassEstLaptime;
+                    const float C = ir_CarIdxEstTime.getFloat(i) / LClassRatio;
                     const float S = ir_CarIdxEstTime.getFloat(ir_session.driverCarIdx);
 
                     // Does the delta between us and the other car span across the start/finish line?
@@ -129,7 +131,7 @@ class OverlayRelative : public Overlay
 
                     if( wrap )
                     {
-                        delta     = S > C ? (C-S)+L : (C-S)-L;
+                        delta     = S > C ? (C-S)+ownClassEstLaptime : (C-S)-ownClassEstLaptime;
                         lapDelta += S > C ? -1 : 1;
                     }
                     else

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ At the top is an optional minimap. It can be set to either relative mode (own ca
 
 A dashboard that concentrates important pieces of information for which you would otherwise have to flip through various boxes in iRacing.
 
-The fuel calculator shows the estimated remaining laps, remaining amount of fuel, estimated fuel used per lap, estimated _additional_ fuel required to finish the race, and the fuel amount that is scheduled to be added on the next pit stop. To compute the estimated fuel consumption, the last 4 laps under green and without pit stops are taken into account, and a 5% safety margin is added. These parameters can be customized.
+The fuel calculator shows the estimated remaining laps, remaining amount of fuel, estimated fuel used per lap, estimated _additional_ fuel required to finish the race, and the fuel amount that is scheduled to be added on the next pit stop. To compute the estimated fuel consumption, the last 4 laps under green and without pit stops are taken into account, and a configurable safety margin is added. These parameters can be customized.
 
 ![ddu](https://github.com/lespalt/iRon/blob/main/ddu.png?raw=true)
 
@@ -83,6 +83,14 @@ Overlays can be switched on and off at runtime using the hotkeys displayed durin
 Certain aspects of the overlays, such as colors, font types, sizes etc. can be customized. To do that, open the file **config.json** that iRon created and experiment by editing the (hopefully mostly self-explanatory) parameters. You can do that while the app is running -- the changes will take effect immediately whenever the file is saved.
 
 _Note that currently, the config file will be created only after the overlays have been "touched" for the first time, usually by dragging or resizing them._
+
+##### Fuel calculator
+Fuel in laps = ( Remaining_Fuel - Reserve Fuel ) / (Average_Use x Fuel_Estimate_Factor) 
+
+Vars: 
+fuel_estimate_avg_green_laps: Amount of laps to average in the lap calculation
+fuel_estimate_factor: Amount to multiply the fuel use for (coarse safety margin)
+fuel_reserve_margin: Amount of fuel to reserve in the calculations
 
 ---
 


### PR DESCRIPTION
Hello, guess i will post this here as it seems to be more recent!

The Relative was basing it's calculations on the players "Estimated lap time", so all slower/faster cars were offset by some amount.
Now it uses the values at the opponent carClassEstLapTime and its own carClassEstLapTime to calculate that difference.

On the DDU Overlay, the Fuel values and labels are now staggered to make space for a 2nd decimal, and it also has a fuel_reserve_margin to ignore some amount of fuel for the calculations (Default: 0.25L, when the car starts choffing)

Hope someone finds this useful!